### PR TITLE
Add config.ru for rackup

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require './lib/app.rb'
+run QuantumSprinkles

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,2 @@
 require './lib/app.rb'
-run QuantumSprinkles
+run Sinatra::Application

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,7 +1,5 @@
 require 'sinatra'
 
-class QuantumSprinkles < Sinatra::Base
-  get '/' do
-    'Quantum Sprinkles'
-  end
+get '/' do
+  'Quantum Sprinkles'
 end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,5 +1,7 @@
 require 'sinatra'
 
-get '/' do
-  'Quantum Sprinkles'
+class QuantumSprinkles < Sinatra::Base
+  get '/' do
+    'Quantum Sprinkles'
+  end
 end


### PR DESCRIPTION
Instead of running the app with `ruby lib/app.rb`, we can run `rackup` to start the app. This changes the default port from 4567 (Sinatra) to 9292 (Rack).

This gives us better control out on the server.